### PR TITLE
Cleanup: Removed duplicate password field in signup form

### DIFF
--- a/apps/app_core/lib/modules/auth/sign_up/screens/sign_up_screen.dart
+++ b/apps/app_core/lib/modules/auth/sign_up/screens/sign_up_screen.dart
@@ -66,7 +66,6 @@ class SignUpPage extends StatelessWidget implements AutoRouteWrapper {
               SlideAndFadeAnimationWrapper(delay: 300, child: _NameInput()),
               SlideAndFadeAnimationWrapper(delay: 300, child: _EmailInput()),
               SlideAndFadeAnimationWrapper(delay: 400, child: _PasswordInput()),
-              SlideAndFadeAnimationWrapper(delay: 400, child: _PasswordInput()),
               SlideAndFadeAnimationWrapper(delay: 400, child: _ConfirmPasswordInput()),
               SlideAndFadeAnimationWrapper(delay: 400, child: _UserConsentWidget()),
               const SlideAndFadeAnimationWrapper(delay: 600, child: _CreateAccountButton()),


### PR DESCRIPTION
## Description

Removed the duplicate password field from the signup screen to streamline the user interface and avoid confusion. Now, the screen includes only one password input and one confirm password input for a clearer signup experience.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore